### PR TITLE
Replace NeDB with the seedable memory adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Example JSON API prototype using Fortune.js
 [Fortune.js](https://fortune.js.org/) is handy for prototyping [JSON:API](https://jsonapi.org/) formatted APIs.
 
-This example extends [Fortune's Getting Started guide](https://fortune.js.org/guide/) to demonstrate a simple prototype using Fortune's JSON:API serializer and its [NeDB](https://github.com/louischatriot/nedb) adapter for file-based persistence.
+This example extends [Fortune's Getting Started guide](https://fortune.js.org/guide/) to demonstrate a simple prototype using the [JSON:API serializer](https://www.npmjs.com/package/fortune-json-api) and [seedable memory adapter](https://www.npmjs.com/package/fortune-seedable-memory).
 
-I find this combination especially handy: the flat files used by NeDB (found in the `db` directory of this repo) are easy to parse and edit manually, and with just a few lines of code Fortune.js can serialize their contents as a JSON:API.
+It's a handy combination for testing and prototyping: the [.jsonl](https://jsonlines.org/) seed files (found in the `db` directory of this repo) are easy to read and edit manually, and with just a few lines of code Fortune can serialize their contents as a JSON:API.
 
 ## Installation
 * `git clone https://github.com/redoPop/fortunejs-example.git`
@@ -20,9 +20,9 @@ The JSON:API is now available on port 1337 of your localhost.
 ## Example requests
 To keep things simple, I've stuck with the original example presented in the Fortune.js Getting Started guide: a basic API for a Twitter-like service consisting of only `/users` and `/posts`. You'll find the schema definition in `lib/store.js`, along with some expository comments.
 
-I've intentionally avoided transformations and other techniques introduced in Fortune's guide to focus this example on JSON:API serialization of file-persisted data.
+I've intentionally avoided transformations and other techniques introduced in Fortune's guide to focus this example on JSON:API serialization of data.
 
-To the same end, I've also added some seed data which you'll find in the `db` directory of this repository (`db/post.db`, `db/user.db`).
+To the same end, I've also added some seed data which you'll find in the `db` directory of this repository (`db/post.jsonl`, `db/user.jsonl`).
 
 ### Retrieve all posts
 ```

--- a/db/post.db
+++ b/db/post.db
@@ -1,3 +1,0 @@
-{"_id":1,"message":"Sugar peas!","author":5,"in-reply-to":null,"replies":[2]}
-{"_id":2,"message":"@Catbug Drop 'em!","author":4,"in-reply-to":1,"replies":[3]}
-{"_id":3,"message":"@Danny Okay!","author":5,"in-reply-to":2,"replies":[]}

--- a/db/post.jsonl
+++ b/db/post.jsonl
@@ -1,0 +1,3 @@
+{"id":1, "message":"Sugar peas!", "author":5, "in-reply-to":null, "replies":[2]}
+{"id":2, "message":"@Catbug Drop 'em!", "author":4, "in-reply-to":1, "replies":[3]}
+{"id":3, "message":"@Danny Okay!", "author":5, "in-reply-to":2, "replies":[]}

--- a/db/user.db
+++ b/db/user.db
@@ -1,5 +1,0 @@
-{"_id":1,"name":"Chris","following":[2,3,4,5],"followers":[2,3,4],"posts":[]}
-{"_id":2,"name":"Beth","following":[1,3,4,5],"followers":[1,3,4],"posts":[]}
-{"_id":3,"name":"Wallow","following":[1,2,4,5],"followers":[1,2,4,5],"posts":[]}
-{"_id":4,"name":"Danny","following":[1,2,3,5],"followers":[1,2,3],"posts":[2]}
-{"_id":5,"name":"Catbug","following":[3],"followers":[1,2,3,4],"posts":[1,3]}

--- a/db/user.jsonl
+++ b/db/user.jsonl
@@ -1,0 +1,5 @@
+{"id":1, "name":"Chris", "following":[2,3,4,5], "followers":[2,3,4], "posts":[]}
+{"id":2, "name":"Beth", "following":[1,3,4,5], "followers":[1,3,4], "posts":[]}
+{"id":3, "name":"Wallow", "following":[1,2,4,5], "followers":[1,2,4,5], "posts":[]}
+{"id":4, "name":"Danny", "following":[1,2,3,5], "followers":[1,2,3], "posts":[2]}
+{"id":5, "name":"Catbug", "following":[3], "followers":[1,2,3,4], "posts":[1,3]}

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,5 +1,5 @@
 import fortune from 'fortune';
-import nedbAdapter from 'fortune-nedb';
+import adapter from 'fortune-seedable-memory';
 import path from 'path';
 
 const recordTypes = {
@@ -27,11 +27,11 @@ const recordTypes = {
 };
 
 const adapterOptions = {
-  dbPath: path.resolve('./db'),
+  dbPath: path.resolve('db'),
 };
 
 const store = fortune(recordTypes, {
-  adapter: [nedbAdapter, adapterOptions],
+  adapter: [adapter, adapterOptions],
 });
 
 export default store;

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,11 +129,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
@@ -162,14 +157,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "binary-search-tree": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
-      "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
-      "requires": {
-        "underscore": "~1.4.4"
-      }
     },
     "bindings": {
       "version": "1.5.0",
@@ -840,13 +827,10 @@
         "uri-templates": "^0.2.0"
       }
     },
-    "fortune-nedb": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/fortune-nedb/-/fortune-nedb-1.1.7.tgz",
-      "integrity": "sha512-BREoLCzpSmC+cmh7RhFITEOptR19ax92BgRLc9n6WkNmI2Ef2a8V6iWu1BZFiQY94Dmia5jyNhdC22q6zy+BIQ==",
-      "requires": {
-        "nedb": "^1.8.0"
-      }
+    "fortune-seedable-memory": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fortune-seedable-memory/-/fortune-seedable-memory-1.0.0.tgz",
+      "integrity": "sha512-jcP/02sTJBxEODahVtcGBpbNd87SMdw4YDoSUnyNFpCjDTUbNo2J8kcfP25BhjmVIc2KZHXhow8u7VYYIpREpA=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -988,11 +972,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -1221,22 +1200,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
-    "localforage": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.4.tgz",
-      "integrity": "sha512-3EmVZatmNVeCo/t6Te7P06h2alGwbq8wXlSkcSXMvDE2/edPmsVqTPlzGnZaqwZZDBs6v+kxWpqjVsqsNJT8jA==",
-      "requires": {
-        "lie": "3.1.1"
-      }
-    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1273,12 +1236,14 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -1400,18 +1365,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "nedb": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
-      "integrity": "sha1-DjUCzYLABNU1WkPJ5VV3vXvZHYg=",
-      "requires": {
-        "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "~0.5.1",
-        "underscore": "~1.4.4"
-      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -1823,11 +1776,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fortune": "^5.5.0",
     "fortune-http": "^1.2.0",
     "fortune-json-api": "^2.2.0",
-    "fortune-nedb": "^1.1.0"
+    "fortune-seedable-memory": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^7.4.0",


### PR DESCRIPTION
NeDB is not currently being maintained and its dependencies have multiple high severity vulnerabilities.

This PR replaces it with [the seedable memory adapter](https://www.npmjs.com/package/fortune-seedable-memory), an extension of Fortune's built-in memory adapter with the added capability of seeding data from JSONL-formatted files very similar to those used by NeDB.